### PR TITLE
Fix: clamp DNS cache TTL floor to prevent ttlcache panic on TTL=0

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -17,10 +17,7 @@ import (
 
 const (
 	maxCacheTTL = 5 * time.Minute
-	// minCacheTTL is the floor applied before handing a TTL to the cache.
-	// ttlcache.Set panics on TTLs below 1ms, and upstream DNS can legitimately
-	// return TTL=0 (e.g. CDN load-balancer records), which would otherwise
-	// crash the resolver on every such lookup.
+	// minCacheTTL is the floor applied before handing a TTL to the cache
 	minCacheTTL = time.Second
 )
 
@@ -143,8 +140,8 @@ func (r *TailscaleResolver) resolveDNS(ctx context.Context, name string, qt stri
 	return addrs, ttl, nil
 }
 
-// clampCacheTTL bounds a DNS-derived TTL to the range [minCacheTTL, maxCacheTTL]
-// before it is handed to ttlcache.Set, which panics on TTLs below 1ms.
+// clampCacheTTL bounds a DNS-derived TTL to the range [minCacheTTL, maxCacheTTL] before it is handed to ttlcache.Set, which panics on TTLs below 1ms
+// Upstream DNS can legitimately return TTL=0 (e.g. CDN load-balancer records)
 func clampCacheTTL(ttl time.Duration) time.Duration {
 	if ttl < minCacheTTL {
 		return minCacheTTL

--- a/resolver.go
+++ b/resolver.go
@@ -15,7 +15,14 @@ import (
 	"tailscale.com/client/local"
 )
 
-const maxCacheTTL = 5 * time.Minute
+const (
+	maxCacheTTL = 5 * time.Minute
+	// minCacheTTL is the floor applied before handing a TTL to the cache.
+	// ttlcache.Set panics on TTLs below 1ms, and upstream DNS can legitimately
+	// return TTL=0 (e.g. CDN load-balancer records), which would otherwise
+	// crash the resolver on every such lookup.
+	minCacheTTL = time.Second
+)
 
 // TailscaleResolver resolves DNS names through Tailscale
 type TailscaleResolver struct {
@@ -78,12 +85,12 @@ func (r *TailscaleResolver) Resolve(ctx context.Context, name string) (context.C
 	// Check if we have an A record first, then AAAA
 	if res.A.err == nil && len(res.A.records) > 0 {
 		ip := res.A.records[0].AsSlice()
-		r.cache.Set(name, ip, min(res.A.ttl, maxCacheTTL))
+		r.cache.Set(name, ip, clampCacheTTL(res.A.ttl))
 		return ctx, ip, nil
 	}
 	if res.AAA.err == nil && len(res.AAA.records) > 0 {
 		ip := res.AAA.records[0].AsSlice()
-		r.cache.Set(name, ip, min(res.AAA.ttl, maxCacheTTL))
+		r.cache.Set(name, ip, clampCacheTTL(res.AAA.ttl))
 		return ctx, ip, nil
 	}
 
@@ -134,6 +141,18 @@ func (r *TailscaleResolver) resolveDNS(ctx context.Context, name string, qt stri
 		return nil, 0, fmt.Errorf("parse %s response: %w", qt, err)
 	}
 	return addrs, ttl, nil
+}
+
+// clampCacheTTL bounds a DNS-derived TTL to the range [minCacheTTL, maxCacheTTL]
+// before it is handed to ttlcache.Set, which panics on TTLs below 1ms.
+func clampCacheTTL(ttl time.Duration) time.Duration {
+	if ttl < minCacheTTL {
+		return minCacheTTL
+	}
+	if ttl > maxCacheTTL {
+		return maxCacheTTL
+	}
+	return ttl
 }
 
 func (r *TailscaleResolver) ensureTrailingDot(s string) string {


### PR DESCRIPTION
## Summary

The DNS resolver panics with `invalid TTL: must be 1ms or greater` whenever an upstream DNS record is returned with TTL=0, crashing the entire tailsocks process.

## Repro

Any SOCKS5 client request whose hostname resolves to an A/AAAA record with `TTL=0` triggers this every time. TTL=0 is legitimate and fairly common — CDNs and load balancers use it to tell clients not to cache. Observed on v1.2.0 and still present on v1.2.3 / main.

A shortened trace of the panic:

```
panic: invalid TTL: must be 1ms or greater

goroutine 4919 [running]:
github.com/italypaleale/go-kit/ttlcache.(*Cache[...]).Set
    ttlcache.go:90 +0xf4
main.(*TailscaleResolver).Resolve
    resolver.go:81 +0x268
github.com/armon/go-socks5.(*Server).handleRequest
    request.go:125 +0x74
github.com/armon/go-socks5.(*Server).ServeConn
    socks5.go:162 +0x5a4
```

## Root cause

`resolver.go:81` and `:86` bound the cached TTL with `min(res.A.ttl, maxCacheTTL)` — capping the ceiling but not enforcing any floor. `ttlcache.Set` panics on TTLs below 1ms (see `go-kit/ttlcache/ttlcache.go:89-91`), so any upstream TTL of 0 is passed straight through and crashes the resolver goroutine.

In my setup this took down the proxy 3–10 times a day, which an auto-restart wrapper has been hiding. The `Resolve` method already swallows no result cleanly when the panic would have occurred, so there is no correctness-based reason not to cache a short-but-nonzero duration.

## Fix

- Introduce `minCacheTTL = time.Second` alongside the existing `maxCacheTTL`
- Add a `clampCacheTTL` helper that bounds a DNS-derived TTL into `[minCacheTTL, maxCacheTTL]`
- Use it at both cache-set sites

1s was chosen as a pragmatic floor: small enough that CDN/load-balancer rotation behavior is effectively preserved (a single connection may target a briefly-stale IP, which is usually fine for SOCKS5 usage), and large enough to provide meaningful cache benefit for clients that burst-resolve the same name.

Open to pushing the floor lower (e.g. `10*time.Millisecond`) or making it configurable — flagging that as preference.

## Test plan

- [x] Built patched binary, ran under the same workload that previously triggered the panic multiple times per day; no crashes in 24h monitoring
- [x] Verified SOCKS5 proxy still resolves through Tailscale DNS (MagicDNS and external names), egress IP still routed through selected exit node
- [ ] No unit tests exist for the resolver cache path yet — happy to add one (inject a `ttl=0` response and assert `Resolve` does not panic) if desired