### PR TITLE
Bump tailscale.com to v1.102.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.56.0
-	tailscale.com v1.102.1
+	tailscale.com v1.102.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -256,5 +256,5 @@ k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3 h1:jVkFFVfXdXP74B/zbO3hM3hpSFD0x
 k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3/go.mod h1:M2s5JB1lIYP3jzZdorPLHXIPJzt9vv2muW5a6L9DtNM=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.102.1 h1:l5ZttM2aHXwcVsMdbQnGuLiAQCvkK8HHy0VI2yHlAys=
-tailscale.com v1.102.1/go.mod h1:ynxKzc9hDxwGLHORQE0qrTH1b8NBRrIsXcnfnug/3dg=
+tailscale.com v1.102.2 h1:K0TJMOFv0F9aJDSjM/C2uVtrwnLn+ek22c42x61FXeA=
+tailscale.com v1.102.2/go.mod h1:ynxKzc9hDxwGLHORQE0qrTH1b8NBRrIsXcnfnug/3dg=


### PR DESCRIPTION
## Summary

Automated dependency bump: `tailscale.com` v1.102.1 → v1.102.2, tracking Tailscale's official stable release channel ([changelog](https://tailscale.com/changelog)). This release includes a fix for a Funnel connection regression.

## Changes

- `go.mod`: `tailscale.com v1.102.1` → `v1.102.2`
- `go.sum`: updated checksums via `go mod tidy`

## Test plan

- [x] `go get tailscale.com@v1.102.2` + `go mod tidy` — clean, no unrelated dependency churn
- [x] `go build ./...` — passed
- [x] `go vet ./...` — passed
- [x] `go test ./... -short` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RtMbbBxzYH9Vt2doauysWx)_